### PR TITLE
Windows signed build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,7 +62,6 @@ jobs:
 
   PublishWindows:
     runs-on: windows-latest
-    environment: WindowsSigned
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET


### PR DESCRIPTION
PR runs do not sign, while pushes and manual runs do.