### PR TITLE
Fix handling of RTC dates

### DIFF
--- a/src/DreamPotato.MonoGame/Game1.cs
+++ b/src/DreamPotato.MonoGame/Game1.cs
@@ -134,7 +134,7 @@ public class Game1 : Game
             var vmu = presenter.Vmu;
             vmu.InitializeFlash(date);
             if (Configuration.AutoInitializeDate)
-                vmu.InitializeDate(date);
+                vmu.InitializeRTCDate(date);
 
             vmu.LoadRom();
             if (vmsOrVmuFilePath != null && File.Exists(vmsOrVmuFilePath))
@@ -201,10 +201,11 @@ public class Game1 : Game
     internal void LoadAndStartVmsOrVmuFile(VmuPresenter presenter, string filePath)
     {
         var vmu = presenter.Vmu;
+        var date = DateTimeOffset.Now;
         var extension = Path.GetExtension(filePath);
         if (extension.Equals(".vms", StringComparison.OrdinalIgnoreCase))
         {
-            vmu.LoadGameVms(filePath, DateTime.Now);
+            vmu.LoadGameVms(filePath, date, autoInitializeRTCDate: Configuration.AutoInitializeDate);
         }
         else if (extension.Equals(".vmu", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".bin", StringComparison.OrdinalIgnoreCase))
@@ -242,7 +243,7 @@ public class Game1 : Game
                 return false;
             }
 
-            vmu.LoadVmu(filePath, DateTime.Now);
+            vmu.LoadVmu(filePath, rtcDate: Configuration.AutoInitializeDate ? date : null);
             return true;
         }
     }

--- a/src/DreamPotato.Tests/SerialTests.cs
+++ b/src/DreamPotato.Tests/SerialTests.cs
@@ -103,7 +103,7 @@ public class SerialTests
         cpuTx.DisplayName = "Sender";
         cpuTx.DreamcastSlot = DreamcastSlot.Slot1;
         vmuTx.LoadRom();
-        vmuTx.LoadGameVms("TestSource/helloworld.vms", date: DateTimeOffset.Parse("09/09/1999"));
+        vmuTx.LoadGameVms("TestSource/helloworld.vms", date: DateTimeOffset.Parse("09/09/1999"), autoInitializeRTCDate: true);
 
         const long halfSecond = TimeSpan.TicksPerSecond / 2;
         cpuTx.Run(halfSecond);


### PR DESCRIPTION
AutoInitializeDate was not being respected at startup.

It is an ear-piercing behavior, but, seems correct to respect it both when initially starting and when resetting.