### PR TITLE
.dci file support

### DIFF
--- a/src/DreamPotato.Core/FileFormat.cs
+++ b/src/DreamPotato.Core/FileFormat.cs
@@ -1,0 +1,15 @@
+namespace DreamPotato.Core;
+
+/// <summary>Possible file formats for storing VMU files on the host file system.</summary>
+public enum FileFormat
+{
+    /// <summary>
+    /// .vmi+.vms file pair.
+    /// https://vmu.falcogirgis.net/formats.html#formats_vmi
+    /// https://vmu.falcogirgis.net/formats.html#formats_vms
+    /// </summary>
+    VmiVms,
+
+    /// <summary>https://vmu.falcogirgis.net/formats.html#formats_dci</summary>
+    Dci,
+}

--- a/src/DreamPotato.Core/FileFormat.cs
+++ b/src/DreamPotato.Core/FileFormat.cs
@@ -13,3 +13,8 @@ public enum FileFormat
     /// <summary>https://vmu.falcogirgis.net/formats.html#formats_dci</summary>
     Dci,
 }
+
+public static class FileFormatExtensions
+{
+    public static string[] Names { get; } = ["vmi/vms", "dci"];
+}

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -261,8 +261,7 @@ internal class FileSystem
 
     public (bool ok, string? errorMessage) TryWriteGameFileWithVmi(Stream vmsFile, string onDiskFileName, VmiInfo vmiInfo)
     {
-        // Create a directory entry
-        var directoryEntry = CreateDirectoryEntry(vmiInfo);
+        var directoryEntry = TryCreateDirectoryEntry(vmiInfo);
         if (!directoryEntry.HasValue)
             return (false, $"{onDiskFileName}: The file system directory is full.");
 
@@ -319,7 +318,7 @@ internal class FileSystem
     }
 
     /// <summary>Read all the files from this file system to destDirectory.</summary>
-    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory, FileFormat fileFormat)
+    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory, FileFormat preferredFileFormat)
     {
         HashSet<string> allFilePaths = [];
         foreach (var directoryEntry in EnumerateDirectoryTable())
@@ -345,15 +344,17 @@ internal class FileSystem
             var outFileName = directoryEntry.NameString;
             var fatBlock = GetFATBlock();
 
-            if (fileFormat == FileFormat.Dci)
+            if (preferredFileFormat == FileFormat.Dci)
             {
                 // dci format consists of the directory entry content, followed by vms data as a sequence of big-endian ints.
                 using var dciFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.dci"));
 
-                var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
-                directoryEntry.RawData.CopyTo(outEntry.RawData);
-                outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
-                dciFile.Write(outEntry.RawData.Span);
+                {
+                    var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
+                    directoryEntry.RawData.CopyTo(outEntry.RawData);
+                    outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
+                    dciFile.Write(outEntry.RawData.Span);
+                }
 
                 Span<byte> swappedBlock = new byte[BlockSize];
                 for (var blockId = directoryEntry.StartFAT;
@@ -370,6 +371,7 @@ internal class FileSystem
                 return;
             }
 
+            Debug.Assert(preferredFileFormat == FileFormat.VmiVms);
             using var vmsFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.vms"));
 
             for (var blockId = directoryEntry.StartFAT;
@@ -444,13 +446,13 @@ internal class FileSystem
         return (ok, error);
     }
 
-    private readonly struct VmiFileNameInfo(string vmuFileName, string onDiskFileName) : IEquatable<VmiFileNameInfo>
+    private readonly struct VmuFileNameInfo(string vmuFileName, string onDiskFileName) : IEquatable<VmuFileNameInfo>
     {
         public readonly string VmuFileName = vmuFileName;
         public readonly string OnDiskFileName = onDiskFileName;
 
-        public bool Equals(VmiFileNameInfo other) => VmuFileName == other.VmuFileName;
-        public override bool Equals(object? obj) => obj is VmiFileNameInfo info && Equals(info);
+        public bool Equals(VmuFileNameInfo other) => VmuFileName == other.VmuFileName;
+        public override bool Equals(object? obj) => obj is VmuFileNameInfo info && Equals(info);
         public override int GetHashCode() => VmuFileName.GetHashCode();
     }
 
@@ -462,10 +464,11 @@ internal class FileSystem
     private (bool ok, string? errorMessage) TryWriteAllFiles(DirectoryInfo sourceDirectory)
     {
         string? foundGameName = null;
-        HashSet<VmiFileNameInfo> allVmuFileNames = [];
+        HashSet<VmuFileNameInfo> allVmuFileNames = [];
 
         // Data (non-game) files are written from the end of the user region toward the start
         ushort currentDataBlockId = UserRegionLastBlockId;
+
         foreach (var vmsFileInfo in sourceDirectory.EnumerateFiles("*.vms").OrderBy(f => f.Name))
         {
             if (vmsFileInfo.Length == 0)
@@ -479,7 +482,7 @@ internal class FileSystem
                 return (false, $"{vmiFileInfo.Name}: Bad format");
 
             var vmiInfo = new VmiInfo(File.ReadAllBytes(vmiFileInfo.FullName));
-            var vmiFileNameInfo = new VmiFileNameInfo(vmiInfo.VmuFileNameString, vmiFileInfo.Name);
+            var vmiFileNameInfo = new VmuFileNameInfo(vmiInfo.VmuFileNameString, vmiFileInfo.Name);
             if (allVmuFileNames.TryGetValue(vmiFileNameInfo, out var existingNameInfo))
                 return (false, $"VMU filename '{vmiFileNameInfo.VmuFileName}' is duplicated by '{existingNameInfo.OnDiskFileName}' and '{vmiFileNameInfo.OnDiskFileName}'.");
 
@@ -502,13 +505,8 @@ internal class FileSystem
                 return (false, error1);
         }
 
-        // TODO2: When DC reads the files added this way, it reports they are corrupted.
-        // Probably need to write some actual tests to figure out what's wrong here.
         foreach (var dciFileInfo in sourceDirectory.EnumerateFiles("*.dci").OrderBy(f => f.Name))
         {
-            if (dciFileInfo.Length == 0)
-                return (false, $"{dciFileInfo.Name}: Cannot write an empty file");
-
             var vmsContentLength = dciFileInfo.Length - DirectoryEntry.Size;
             if (vmsContentLength % BlockSize != 0)
                 return (false, $"{dciFileInfo.Name}: Invalid format");
@@ -517,10 +515,19 @@ internal class FileSystem
             if (!directoryEntry.HasValue)
                 return (false, $"{dciFileInfo.Name}: The VMU file system directory is full.");
 
-            var dciFile = dciFileInfo.OpenRead();
+            using var dciFile = dciFileInfo.OpenRead();
             dciFile.ReadExactly(directoryEntry.RawData.Span);
             if (directoryEntry.Type is not (FileType.Game or FileType.Data))
                 return (false, $"{dciFileInfo.Name}: Invalid format");
+
+            if (vmsContentLength / BlockSize != directoryEntry.SizeInBlocks)
+                return (false, $"{dciFileInfo.Name}: Invalid format");
+
+            var vmiFileNameInfo = new VmuFileNameInfo(directoryEntry.NameString, dciFileInfo.Name);
+            if (allVmuFileNames.TryGetValue(vmiFileNameInfo, out var existingNameInfo))
+                return (false, $"VMU filename '{vmiFileNameInfo.VmuFileName}' is duplicated by '{existingNameInfo.OnDiskFileName}' and '{vmiFileNameInfo.OnDiskFileName}'.");
+
+            allVmuFileNames.Add(vmiFileNameInfo);
 
             if (directoryEntry.Type == FileType.Game)
             {
@@ -546,21 +553,62 @@ internal class FileSystem
         return (true, null);
     }
 
+    public (bool ok, string? error) TryWriteDciFile(FileInfo dciFileInfo)
+    {
+        var vmsContentLength = dciFileInfo.Length - DirectoryEntry.Size;
+        if (vmsContentLength % BlockSize != 0)
+            return (false, $"{dciFileInfo.Name}: Invalid format");
+
+        var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
+        if (!directoryEntry.HasValue)
+            return (false, $"{dciFileInfo.Name}: The VMU file system directory is full.");
+
+        using var dciFile = dciFileInfo.OpenRead();
+        dciFile.ReadExactly(directoryEntry.RawData.Span);
+        if (directoryEntry.Type is not (FileType.Game or FileType.Data))
+            return (false, $"{dciFileInfo.Name}: Invalid format");
+
+        if (vmsContentLength / BlockSize != directoryEntry.SizeInBlocks)
+            return (false, $"{dciFileInfo.Name}: Invalid format");
+
+        if (directoryEntry.Type == FileType.Game)
+        {
+            if (TryWriteGameFile(dciFile, directoryEntry) is (false, var error))
+                return (false, error);
+        }
+        else
+        {
+            var currentDataBlockId = UserRegionLastBlockId;
+            if (TryWriteDataFile(ref currentDataBlockId, dciFile, directoryEntry) is (false, var error1))
+                return (false, error1);
+        }
+
+        // Above TryWrite.. call read the dci file straight from disk into flash.
+        // Now we need to reverse the 32-bit big-endian encoding in-place to get the proper vms content.
+        var fatBlock = GetFATBlock();
+        for (var blockId = directoryEntry.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+        {
+            var block = MemoryMarshal.Cast<byte, int>(GetBlock(blockId));
+            BinaryPrimitives.ReverseEndianness(source: block, destination: block);
+        }
+
+        return (true, null);
+    }
+
     public (bool ok, string? error) TryWriteDataFileWithVmi(ref ushort currentDataBlockId, Stream vmsFile, VmiInfo vmiInfo)
     {
         if (vmsFile.RemainingLength() != vmiInfo.VmsFileSize)
             return (false, $"{vmiInfo.VmuFileNameString}: VMI expected the VMS file size to be {vmiInfo.VmsFileSize} but was actually {vmsFile.RemainingLength()}");
 
-        var directoryEntry = CreateDirectoryEntry(vmiInfo);
+        var directoryEntry = TryCreateDirectoryEntry(vmiInfo);
         if (!directoryEntry.HasValue)
             return (false, $"{vmiInfo.VmuFileNameString}: The file system directory is full.");
 
-        // Note: directoryEntry.StartFAT is deliberately only set by the inner helper method
         return TryWriteDataFile(ref currentDataBlockId, vmsFile, directoryEntry);
     }
 
     /// <summary>NOTE: does not populate <see cref="DirectoryEntry.StartFAT"/>.</summary>
-    public DirectoryEntry CreateDirectoryEntry(VmiInfo vmiInfo)
+    public DirectoryEntry TryCreateDirectoryEntry(VmiInfo vmiInfo)
     {
         var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
         if (!directoryEntry.HasValue)
@@ -931,7 +979,7 @@ internal class FileSystem
                 continue;
 
             hostFileInfo.Delete();
-            if (hostFileInfo.Name.EndsWith(".vmi"))
+            if (hostFileInfo.Name.EndsWith(".vmi", StringComparison.OrdinalIgnoreCase))
                 File.Delete(Path.ChangeExtension(hostFileInfo.FullName, ".vms"));
         }
 
@@ -940,9 +988,9 @@ internal class FileSystem
             var onVmuFileName = entryToWrite.NameString;
             if (hostFilesByVmuFileName.TryGetValue(entryToWrite.NameString, out var existingInfo))
             {
-                if (existingInfo.Name.EndsWith(".vmi"))
+                if (existingInfo.Name.EndsWith(".vmi", StringComparison.OrdinalIgnoreCase))
                     writeVmiVms(existingInfo);
-                else if (existingInfo.Name.EndsWith(".dci"))
+                else if (existingInfo.Name.EndsWith(".dci", StringComparison.OrdinalIgnoreCase))
                     writeDci(existingInfo);
                 else
                     throw new InvalidOperationException();
@@ -974,17 +1022,19 @@ internal class FileSystem
 
             void writeDci(FileInfo dciFileInfo)
             {
-                // dci format consists of the directory entry content, followed by the vms data.
+                // dci format consists of the directory entry content, followed by vms data as a sequence of 32-bit big-endian ints.
                 using var dciFile = dciFileInfo.Create();
 
-                var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
-                entryToWrite.RawData.CopyTo(outEntry.RawData);
-                outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
-                dciFile.Write(outEntry.RawData.Span);
+                {
+                    var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
+                    entryToWrite.RawData.CopyTo(outEntry.RawData);
+                    outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
+                    dciFile.Write(outEntry.RawData.Span);
+                }
 
                 var fatBlock = GetFATBlock();
                 Span<byte> swappedBlock = new byte[BlockSize];
-                for (var blockId = outEntry.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+                for (var blockId = entryToWrite.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
                 {
                     var block = GetBlock(blockId);
                     BinaryPrimitives.ReverseEndianness(

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 
 using Microsoft.Win32.SafeHandles;
@@ -260,26 +261,47 @@ internal class FileSystem
 
     public (bool ok, string? errorMessage) TryWriteGameFileWithVmi(Stream vmsFile, string onDiskFileName, VmiInfo vmiInfo)
     {
-        var copyProtection = vmiInfo.FileMode.HasFlag(VmuFileMode.CopyProtected) ? FileCopyProtection.CopyProtected : FileCopyProtection.NotCopyProtected;
-        return TryWriteGameFile(vmsFile, onDiskFileName, onVmuFileName: vmiInfo.VmuFileName, vmiInfo.CreationDateTimeOffset, copyProtection);
+        // Create a directory entry
+        var directoryEntry = CreateDirectoryEntry(vmiInfo);
+        if (!directoryEntry.HasValue)
+            return (false, $"{onDiskFileName}: The file system directory is full.");
+
+        return TryWriteGameFile(vmsFile, directoryEntry);
     }
 
-    public (bool ok, string? errorMessage) TryWriteGameFile(Stream vmsFile, string onDiskFileName, ReadOnlyMemory<byte> onVmuFileName, DateTimeOffset date, FileCopyProtection copyProtection)
+    /// <summary>For use when loading a standalone '.vms' file which we assume is a game.</summary>
+    public (bool ok, string? errorMessage) TryWriteVmsOnlyGame(Stream vmsFile, string onDiskFileName, ReadOnlyMemory<byte> onVmuFileName, DateTimeOffset date, FileCopyProtection copyProtection)
+    {
+        // Create a directory entry
+        var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
+        if (!directoryEntry.HasValue)
+            return (false, $"{onDiskFileName}: The file system directory is full.");
+
+        directoryEntry.Type = FileType.Game;
+        directoryEntry.CopyProtection = copyProtection;
+        onVmuFileName.CopyTo(directoryEntry.Name);
+        directoryEntry.Name.Span[onVmuFileName.Length..].Clear();
+        directoryEntry.DateTimeOffset = date;
+        directoryEntry.SizeInBlocks = (ushort)((vmsFile.Length + BlockSize - 1) / BlockSize);
+        directoryEntry.VmsHeaderBlockOffset = 1;
+
+        return TryWriteGameFile(vmsFile, directoryEntry);
+    }
+
+    public (bool ok, string? errorMessage) TryWriteGameFile(Stream vmsFile, DirectoryEntry directoryEntry)
     {
         var vmsLength = checked((int)(vmsFile.Length - vmsFile.Position));
         ArgumentOutOfRangeException.ThrowIfNegative(vmsLength);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(vmsLength, Cpu.InstructionBankSize);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(onVmuFileName.Length, DirectoryEntry.FileNameLength);
 
-        // Verify sufficient free space
+        // Game files must be written contiguously starting at block 0.
+        // Verify sufficient free space.
         var fatBlock = GetFATBlock();
         var lastBlockId = (vmsLength + BlockSize - 1) / BlockSize - 1;
         for (int i = 0; i <= lastBlockId; i++)
         {
             if (fatBlock[i] != FAT_Unallocated)
-            {
-                return (false, $"{onDiskFileName}: Insufficient space");
-            }
+                return (false, $"{directoryEntry.NameString}: Insufficient space");
         }
 
         // Update FAT table indicating the game data starts at block 0 and grows toward the end
@@ -290,21 +312,8 @@ internal class FileSystem
 
         fatBlock[lastBlockId] = FAT_LastInFile;
 
-        // Game data itself must be written to start of bank 0
         vmsFile.ReadExactly(flash.AsSpan(0, vmsLength));
-
-        // Create a directory entry
-        var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
-        if (!directoryEntry.HasValue)
-            return (false, $"{onDiskFileName}: The file system directory is full.");
-
-        directoryEntry.Type = FileType.Game;
-        directoryEntry.CopyProtection = copyProtection;
         directoryEntry.StartFAT = 0;
-        onVmuFileName.CopyTo(directoryEntry.Name);
-        directoryEntry.DateTimeOffset = date;
-        directoryEntry.SizeInBlocks = (ushort)((vmsLength + BlockSize - 1) / BlockSize);
-        directoryEntry.VmsHeaderBlockOffset = 1;
 
         return (true, null);
     }
@@ -338,7 +347,7 @@ internal class FileSystem
 
             if (fileFormat == FileFormat.Dci)
             {
-                // dci format consists of the directory entry content, followed by the vms data.
+                // dci format consists of the directory entry content, followed by vms data as a sequence of big-endian ints.
                 using var dciFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.dci"));
 
                 var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
@@ -346,12 +355,16 @@ internal class FileSystem
                 outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
                 dciFile.Write(outEntry.RawData.Span);
 
+                Span<byte> swappedBlock = new byte[BlockSize];
                 for (var blockId = directoryEntry.StartFAT;
                     blockId != FAT_LastInFile;
                     blockId = fatBlock[blockId])
                 {
                     var block = this.GetBlock(blockId);
-                    dciFile.Write(block);
+                    BinaryPrimitives.ReverseEndianness(
+                        source: MemoryMarshal.Cast<byte, int>(block),
+                        destination: MemoryMarshal.Cast<byte, int>(swappedBlock));
+                    dciFile.Write(swappedBlock);
                 }
 
                 return;
@@ -475,7 +488,7 @@ internal class FileSystem
             if (vmiInfo.FileMode.HasFlag(VmuFileMode.Game))
             {
                 if (foundGameName != null)
-                    return (false, $"Cannot use multiple games in VMS folder: '{foundGameName}', '{vmiFileInfo.Name}'");
+                    return (false, $"Cannot load multiple games: '{foundGameName}', '{vmiFileInfo.Name}'");
 
                 foundGameName = vmiFileInfo.Name;
 
@@ -494,6 +507,10 @@ internal class FileSystem
             if (dciFileInfo.Length == 0)
                 return (false, $"{dciFileInfo.Name}: Cannot write an empty file");
 
+            var vmsContentLength = dciFileInfo.Length - DirectoryEntry.Size;
+            if (vmsContentLength % BlockSize != 0)
+                return (false, $"{dciFileInfo.Name}: Invalid format");
+
             var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
             if (!directoryEntry.HasValue)
                 return (false, $"{dciFileInfo.Name}: The VMU file system directory is full.");
@@ -506,19 +523,24 @@ internal class FileSystem
             if (directoryEntry.Type == FileType.Game)
             {
                 if (foundGameName != null)
-                    return (false, $"Cannot use multiple games in VMS folder: '{foundGameName}', '{directoryEntry.Name}'");
+                    return (false, $"Cannot load multiple games: '{foundGameName}', '{directoryEntry.Name}'");
 
                 foundGameName = directoryEntry.NameString;
-                if (TryWriteGameFile(dciFile, onDiskFileName: dciFileInfo.Name, onVmuFileName: directoryEntry.Name, directoryEntry.DateTimeOffset, directoryEntry.CopyProtection) is (false, var error))
+                if (TryWriteGameFile(dciFile, directoryEntry) is (false, var error))
                     return (false, error);
-
-                continue;
             }
-
-            if (TryWriteDataFile(ref currentDataBlockId, dciFile, directoryEntry) is (false, var error1))
+            else if (TryWriteDataFile(ref currentDataBlockId, dciFile, directoryEntry) is (false, var error1))
                 return (false, error1);
-        }
 
+            // Above TryWrite.. call read the dci file straight from disk into flash.
+            // Now we need to reverse the 32-bit big-endian encoding in-place to get the proper vms content.
+            var fatBlock = GetFATBlock();
+            for (var blockId = directoryEntry.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+            {
+                var block = MemoryMarshal.Cast<byte, int>(GetBlock(blockId));
+                BinaryPrimitives.ReverseEndianness(source: block, destination: block);
+            }
+        }
         return (true, null);
     }
 
@@ -527,26 +549,36 @@ internal class FileSystem
         if (vmsFile.Length != vmiInfo.VmsFileSize)
             return (false, $"{vmiInfo.VmuFileNameString}: VMI expected the VMS file size to be {vmiInfo.VmsFileSize} but was actually {vmsFile.Length}");
 
-        var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
+        var directoryEntry = CreateDirectoryEntry(vmiInfo);
         if (!directoryEntry.HasValue)
             return (false, $"{vmiInfo.VmuFileNameString}: The file system directory is full.");
 
+        // Note: directoryEntry.StartFAT is deliberately only set by the inner helper method
+        return TryWriteDataFile(ref currentDataBlockId, vmsFile, directoryEntry);
+    }
 
-        directoryEntry.Type = FileType.Data;
+    /// <summary>NOTE: does not populate <see cref="DirectoryEntry.StartFAT"/>.</summary>
+    public DirectoryEntry CreateDirectoryEntry(VmiInfo vmiInfo)
+    {
+        var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
+        if (!directoryEntry.HasValue)
+            return directoryEntry;
+
+        var isGame = vmiInfo.FileMode.HasFlag(VmuFileMode.Game);
+        directoryEntry.Type = isGame ? FileType.Game : FileType.Data;
         directoryEntry.CopyProtection = vmiInfo.FileMode.HasFlag(VmuFileMode.CopyProtected) ? FileCopyProtection.CopyProtected : FileCopyProtection.NotCopyProtected;
 
         Debug.Assert(vmiInfo.VmuFileName.Length == directoryEntry.Name.Length);
         vmiInfo.VmuFileName.CopyTo(directoryEntry.Name);
 
         directoryEntry.DateTimeOffset = vmiInfo.CreationDateTimeOffset;
-        directoryEntry.SizeInBlocks = (ushort)((vmsFile.Length + BlockSize - 1) / BlockSize);
+        directoryEntry.SizeInBlocks = (ushort)((vmiInfo.VmsFileSize + BlockSize - 1) / BlockSize);
 
         // Note: if the vms doesn't match this convention, then we have no way of really knowing where its header is.
         // We might want to verify the header is in the expected location in 'ReadAllFiles'.
-        directoryEntry.VmsHeaderBlockOffset = 0;
+        directoryEntry.VmsHeaderBlockOffset = (ushort)(isGame ? 1 : 0);
 
-        // Note: directoryEntry.StartFAT is deliberately only set by the inner helper method
-        return TryWriteDataFile(ref currentDataBlockId, vmsFile, directoryEntry);
+        return directoryEntry;
     }
 
     public (bool ok, string? error) TryWriteDataFile(ref ushort currentDataBlockId, Stream vmsFile, DirectoryEntry directoryEntry)
@@ -949,10 +981,14 @@ internal class FileSystem
                 dciFile.Write(outEntry.RawData.Span);
 
                 var fatBlock = GetFATBlock();
-                for (var blockId = outEntry.StartFAT;blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+                Span<byte> swappedBlock = new byte[BlockSize];
+                for (var blockId = outEntry.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
                 {
-                    var block = this.GetBlock(blockId);
-                    dciFile.Write(block);
+                    var block = GetBlock(blockId);
+                    BinaryPrimitives.ReverseEndianness(
+                        source: MemoryMarshal.Cast<byte, int>(block),
+                        destination: MemoryMarshal.Cast<byte, int>(swappedBlock));
+                    dciFile.Write(swappedBlock);
                 }
 
                 return;

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -112,6 +112,8 @@ internal class FileSystem
 
     public (byte a, byte r, byte g, byte b)? VmuColor => GetRootBlock().VmuColor;
 
+    internal FileFormat PreferredFileFormat { get; set; }
+
     /// <summary>Reset data used for tracking folder changes to default state, i.e. no changes detected, no deadline, mirror up-to-date.</summary>
     private void ResetFlushData()
     {
@@ -318,7 +320,7 @@ internal class FileSystem
     }
 
     /// <summary>Read all the files from this file system to destDirectory.</summary>
-    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory, FileFormat preferredFileFormat)
+    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory)
     {
         HashSet<string> allFilePaths = [];
         foreach (var directoryEntry in EnumerateDirectoryTable())
@@ -344,7 +346,7 @@ internal class FileSystem
             var outFileName = directoryEntry.NameString;
             var fatBlock = GetFATBlock();
 
-            if (preferredFileFormat == FileFormat.Dci)
+            if (PreferredFileFormat == FileFormat.Dci)
             {
                 // dci format consists of the directory entry content, followed by vms data as a sequence of big-endian ints.
                 using var dciFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.dci"));
@@ -369,7 +371,7 @@ internal class FileSystem
                 return;
             }
 
-            Debug.Assert(preferredFileFormat == FileFormat.VmiVms);
+            Debug.Assert(PreferredFileFormat == FileFormat.VmiVms);
             using var vmsFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.vms"));
 
             for (var blockId = directoryEntry.StartFAT;
@@ -887,10 +889,6 @@ internal class FileSystem
 
     internal void FlushToFolder(DirectoryInfo vmsFolder)
     {
-        // TODO2: need to propagate this value in.
-        // Passing a param thru all the layers is not scaling, I think we just need a settable property on this.
-        FileFormat preferredFileFormat = FileFormat.Dci;
-
         if (!vmsFolder.Exists)
             throw new InvalidOperationException();
 
@@ -947,19 +945,20 @@ internal class FileSystem
         // If user needs to figure out which of the duplicate files got updated, they can check timestamps.
         var vmisByName = vmsFolder
             .EnumerateFiles("*.vmi")
-            .Where(info => info.Length == VmiInfo.Size)
-            .GroupBy(info => new VmiInfo(File.ReadAllBytes(info.FullName)).VmuFileNameString);
+            .Where(fileInfo => fileInfo.Length == VmiInfo.Size)
+            .Select(fileInfo => (fileInfo, vmuFileName: new VmiInfo(File.ReadAllBytes(fileInfo.FullName)).VmuFileNameString));
 
         var dcisByName = vmsFolder
-                .EnumerateFiles("*.dci")
-                .Where(info => info.Length >= DirectoryEntry.Size)
-                .GroupBy(info => readDciDirectoryEntry(info).NameString);
+            .EnumerateFiles("*.dci")
+            .Where(fileInfo => fileInfo.Length >= DirectoryEntry.Size)
+            .Select(fileInfo => (fileInfo, vmuFileName: readDciDirectoryEntry(fileInfo).NameString));
 
         var hostFilesByVmuFileName = vmisByName
             .Concat(dcisByName)
+            .GroupBy(pair => pair.vmuFileName)
             .ToDictionary(
                 group => group.Key,
-                group => group.First());
+                group => group.First().fileInfo);
 
         DirectoryEntry readDciDirectoryEntry(FileInfo dciFileInfo)
         {
@@ -997,9 +996,9 @@ internal class FileSystem
             }
 
             // new file
-            if (preferredFileFormat == FileFormat.VmiVms)
+            if (PreferredFileFormat == FileFormat.VmiVms)
                 writeVmiVms(new FileInfo(Path.Combine(vmsFolder.FullName, $"{onVmuFileName}.vmi")));
-            else if (preferredFileFormat == FileFormat.Dci)
+            else if (PreferredFileFormat == FileFormat.Dci)
                 writeDci(new FileInfo(Path.Combine(vmsFolder.FullName, $"{onVmuFileName}.dci")));
             else
                 throw new InvalidOperationException();

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -282,7 +282,7 @@ internal class FileSystem
         onVmuFileName.CopyTo(directoryEntry.Name);
         directoryEntry.Name.Span[onVmuFileName.Length..].Clear();
         directoryEntry.DateTimeOffset = date;
-        directoryEntry.SizeInBlocks = (ushort)((vmsFile.Length + BlockSize - 1) / BlockSize);
+        directoryEntry.SizeInBlocks = (ushort)((vmsFile.RemainingLength() + BlockSize - 1) / BlockSize);
         directoryEntry.VmsHeaderBlockOffset = 1;
 
         return TryWriteGameFile(vmsFile, directoryEntry);
@@ -290,7 +290,7 @@ internal class FileSystem
 
     public (bool ok, string? errorMessage) TryWriteGameFile(Stream vmsFile, DirectoryEntry directoryEntry)
     {
-        var vmsLength = checked((int)(vmsFile.Length - vmsFile.Position));
+        var vmsLength = vmsFile.RemainingLength();
         ArgumentOutOfRangeException.ThrowIfNegative(vmsLength);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(vmsLength, Cpu.InstructionBankSize);
 
@@ -548,8 +548,8 @@ internal class FileSystem
 
     public (bool ok, string? error) TryWriteDataFileWithVmi(ref ushort currentDataBlockId, Stream vmsFile, VmiInfo vmiInfo)
     {
-        if (vmsFile.Length != vmiInfo.VmsFileSize)
-            return (false, $"{vmiInfo.VmuFileNameString}: VMI expected the VMS file size to be {vmiInfo.VmsFileSize} but was actually {vmsFile.Length}");
+        if (vmsFile.RemainingLength() != vmiInfo.VmsFileSize)
+            return (false, $"{vmiInfo.VmuFileNameString}: VMI expected the VMS file size to be {vmiInfo.VmsFileSize} but was actually {vmsFile.RemainingLength()}");
 
         var directoryEntry = CreateDirectoryEntry(vmiInfo);
         if (!directoryEntry.HasValue)
@@ -606,7 +606,7 @@ internal class FileSystem
             if (i == sizeInBlocks - 1)
             {
                 // Last block
-                var remaining = (int)vmsFile.Length;
+                var remaining = vmsFile.RemainingLength();
                 while (remaining > BlockSize)
                     remaining -= BlockSize;
 
@@ -1038,6 +1038,12 @@ internal class FileSystem
             }
         }
     }
+}
+
+internal static class StreamExtensions
+{
+    public static int RemainingLength(this Stream stream)
+        => checked((int)(stream.Length - stream.Position));
 }
 
 /// <summary>https://vmu.falcogirgis.net/filesystem.html#fs_dir</summary>

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -502,6 +502,8 @@ internal class FileSystem
                 return (false, error1);
         }
 
+        // TODO2: When DC reads the files added this way, it reports they are corrupted.
+        // Probably need to write some actual tests to figure out what's wrong here.
         foreach (var dciFileInfo in sourceDirectory.EnumerateFiles("*.dci").OrderBy(f => f.Name))
         {
             if (dciFileInfo.Length == 0)

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -357,9 +357,7 @@ internal class FileSystem
                 }
 
                 Span<byte> swappedBlock = new byte[BlockSize];
-                for (var blockId = directoryEntry.StartFAT;
-                    blockId != FAT_LastInFile;
-                    blockId = fatBlock[blockId])
+                for (var blockId = directoryEntry.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
                 {
                     var block = this.GetBlock(blockId);
                     BinaryPrimitives.ReverseEndianness(

--- a/src/DreamPotato.Core/FileSystem.cs
+++ b/src/DreamPotato.Core/FileSystem.cs
@@ -310,7 +310,7 @@ internal class FileSystem
     }
 
     /// <summary>Read all the files from this file system to destDirectory.</summary>
-    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory)
+    public (bool ok, string? error) TryReadAllFiles(DirectoryInfo destDirectory, FileFormat fileFormat)
     {
         HashSet<string> allFilePaths = [];
         foreach (var directoryEntry in EnumerateDirectoryTable())
@@ -335,6 +335,27 @@ internal class FileSystem
         {
             var outFileName = directoryEntry.NameString;
             var fatBlock = GetFATBlock();
+
+            if (fileFormat == FileFormat.Dci)
+            {
+                // dci format consists of the directory entry content, followed by the vms data.
+                using var dciFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.dci"));
+
+                var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
+                directoryEntry.RawData.CopyTo(outEntry.RawData);
+                outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
+                dciFile.Write(outEntry.RawData.Span);
+
+                for (var blockId = directoryEntry.StartFAT;
+                    blockId != FAT_LastInFile;
+                    blockId = fatBlock[blockId])
+                {
+                    var block = this.GetBlock(blockId);
+                    dciFile.Write(block);
+                }
+
+                return;
+            }
 
             using var vmsFile = File.Create(Path.Combine(destDirectory.FullName, $"{outFileName}.vms"));
 
@@ -457,24 +478,52 @@ internal class FileSystem
                     return (false, $"Cannot use multiple games in VMS folder: '{foundGameName}', '{vmiFileInfo.Name}'");
 
                 foundGameName = vmiFileInfo.Name;
-                var copyProtection = vmiInfo.FileMode.HasFlag(VmuFileMode.CopyProtected) ? FileCopyProtection.CopyProtected : FileCopyProtection.NotCopyProtected;
-                if (TryWriteGameFile(vmsFile, onDiskFileName: vmsFileInfo.Name, onVmuFileName: vmiInfo.VmuFileName, vmiInfo.CreationDateTimeOffset, copyProtection) is (false, var error))
+
+                if (TryWriteGameFileWithVmi(vmsFile, onDiskFileName: vmsFileInfo.Name, vmiInfo) is (false, var error))
                     return (false, error);
 
                 continue;
             }
 
-            if (TryWriteDataFile(ref currentDataBlockId, vmsFile, vmiInfo) is (false, var error1))
+            if (TryWriteDataFileWithVmi(ref currentDataBlockId, vmsFile, vmiInfo) is (false, var error1))
+                return (false, error1);
+        }
+
+        foreach (var dciFileInfo in sourceDirectory.EnumerateFiles("*.dci").OrderBy(f => f.Name))
+        {
+            if (dciFileInfo.Length == 0)
+                return (false, $"{dciFileInfo.Name}: Cannot write an empty file");
+
+            var directoryEntry = EnumerateDirectoryTable().FirstOrDefault(entry => entry.Type == FileType.None);
+            if (!directoryEntry.HasValue)
+                return (false, $"{dciFileInfo.Name}: The VMU file system directory is full.");
+
+            var dciFile = dciFileInfo.OpenRead();
+            dciFile.ReadExactly(directoryEntry.RawData.Span);
+            if (directoryEntry.Type is not (FileType.Game or FileType.Data))
+                return (false, $"{dciFileInfo.Name}: Invalid format");
+
+            if (directoryEntry.Type == FileType.Game)
+            {
+                if (foundGameName != null)
+                    return (false, $"Cannot use multiple games in VMS folder: '{foundGameName}', '{directoryEntry.Name}'");
+
+                foundGameName = directoryEntry.NameString;
+                if (TryWriteGameFile(dciFile, onDiskFileName: dciFileInfo.Name, onVmuFileName: directoryEntry.Name, directoryEntry.DateTimeOffset, directoryEntry.CopyProtection) is (false, var error))
+                    return (false, error);
+
+                continue;
+            }
+
+            if (TryWriteDataFile(ref currentDataBlockId, dciFile, directoryEntry) is (false, var error1))
                 return (false, error1);
         }
 
         return (true, null);
     }
 
-    public (bool ok, string? error) TryWriteDataFile(ref ushort currentDataBlockId, Stream vmsFile, VmiInfo vmiInfo)
+    public (bool ok, string? error) TryWriteDataFileWithVmi(ref ushort currentDataBlockId, Stream vmsFile, VmiInfo vmiInfo)
     {
-        Debug.Assert(!vmiInfo.FileMode.HasFlag(VmuFileMode.Game));
-
         if (vmsFile.Length != vmiInfo.VmsFileSize)
             return (false, $"{vmiInfo.VmuFileNameString}: VMI expected the VMS file size to be {vmiInfo.VmsFileSize} but was actually {vmsFile.Length}");
 
@@ -482,19 +531,41 @@ internal class FileSystem
         if (!directoryEntry.HasValue)
             return (false, $"{vmiInfo.VmuFileNameString}: The file system directory is full.");
 
-        var sizeInBlocks = (ushort)((vmsFile.Length + BlockSize - 1) / BlockSize);
+
+        directoryEntry.Type = FileType.Data;
+        directoryEntry.CopyProtection = vmiInfo.FileMode.HasFlag(VmuFileMode.CopyProtected) ? FileCopyProtection.CopyProtected : FileCopyProtection.NotCopyProtected;
+
+        Debug.Assert(vmiInfo.VmuFileName.Length == directoryEntry.Name.Length);
+        vmiInfo.VmuFileName.CopyTo(directoryEntry.Name);
+
+        directoryEntry.DateTimeOffset = vmiInfo.CreationDateTimeOffset;
+        directoryEntry.SizeInBlocks = (ushort)((vmsFile.Length + BlockSize - 1) / BlockSize);
+
+        // Note: if the vms doesn't match this convention, then we have no way of really knowing where its header is.
+        // We might want to verify the header is in the expected location in 'ReadAllFiles'.
+        directoryEntry.VmsHeaderBlockOffset = 0;
+
+        // Note: directoryEntry.StartFAT is deliberately only set by the inner helper method
+        return TryWriteDataFile(ref currentDataBlockId, vmsFile, directoryEntry);
+    }
+
+    public (bool ok, string? error) TryWriteDataFile(ref ushort currentDataBlockId, Stream vmsFile, DirectoryEntry directoryEntry)
+    {
+        Debug.Assert(directoryEntry.Type == FileType.Data);
+
         var fatBlock = GetFATBlock();
 
         // Scan to next free data block
         while (fatBlock[currentDataBlockId] != FAT_Unallocated)
         {
             if (currentDataBlockId == 0)
-                return (false, $"{vmiInfo.VmuFileNameString}: Insufficient space on VMU");
+                return (false, $"{directoryEntry.NameString}: Insufficient space on VMU");
 
             currentDataBlockId--;
         }
 
-        ushort startFAT = currentDataBlockId;
+        directoryEntry.StartFAT = currentDataBlockId;
+        var sizeInBlocks = directoryEntry.SizeInBlocks;
         for (var i = 0; i < sizeInBlocks; i++)
         {
             var dataBlock = GetBlock(currentDataBlockId);
@@ -520,7 +591,7 @@ internal class FileSystem
             do
             {
                 if (currentDataBlockId == 0)
-                    return (false, $"{vmiInfo.VmuFileNameString}: Insufficient space on VMU");
+                    return (false, $"{directoryEntry.NameString}: Insufficient space on VMU");
 
                 currentDataBlockId--;
             } while (fatBlock[currentDataBlockId] != FAT_Unallocated);
@@ -528,19 +599,6 @@ internal class FileSystem
             fatBlock[prevDataBlockId] = currentDataBlockId;
         }
 
-        directoryEntry.Type = FileType.Data;
-        directoryEntry.CopyProtection = vmiInfo.FileMode.HasFlag(VmuFileMode.CopyProtected) ? FileCopyProtection.CopyProtected : FileCopyProtection.NotCopyProtected;
-        directoryEntry.StartFAT = startFAT;
-
-        Debug.Assert(vmiInfo.VmuFileName.Length == directoryEntry.Name.Length);
-        vmiInfo.VmuFileName.CopyTo(directoryEntry.Name);
-
-        directoryEntry.DateTimeOffset = vmiInfo.CreationDateTimeOffset;
-        directoryEntry.SizeInBlocks = sizeInBlocks;
-
-        // Note: if the vms doesn't match this convention, then we have no way of really knowing where its header is.
-        // We might want to verify the header is in the expected location in 'ReadAllFiles'.
-        directoryEntry.VmsHeaderBlockOffset = 0;
         return (true, null);
     }
 
@@ -749,6 +807,10 @@ internal class FileSystem
 
     internal void FlushToFolder(DirectoryInfo vmsFolder)
     {
+        // TODO2: need to propagate this value in.
+        // Passing a param thru all the layers is not scaling, I think we just need a settable property on this.
+        FileFormat preferredFileFormat = FileFormat.Dci;
+
         if (!vmsFolder.Exists)
             throw new InvalidOperationException();
 
@@ -792,10 +854,10 @@ internal class FileSystem
             }
         }
 
-        // Look at all the .vmi files in the host folder, to find which one has a matching VMU filesystem name.
+        // Look at all the .vmi/.dci files in the host folder, to find which one has a matching VMU filesystem name.
         //
         // Note: the filenames in the host file system, are not matched against the vms names.
-        // The user can rename a .vmi+.vms pair to anything they want (as long as the names without extension match)
+        // The user can rename a .dci, or a .vmi+.vms pair to anything they want (as long as the names without extension match)
         // and we will continue to pick the right file up, update it when it changes, etc.
         //
         // Note: VMU filenames can be duplicated (simply by copy+paste+renaming a vmi+vms pair, for example).
@@ -803,40 +865,97 @@ internal class FileSystem
         // This is thought to be preferable to canceling the flush (not saving user's changes to disk),
         // or potentially overwriting all duplicates (unnecessary complexity for an error scenario).
         // If user needs to figure out which of the duplicate files got updated, they can check timestamps.
-        var vmiFilesByVmuFileName = vmsFolder
+        var vmisByName = vmsFolder
             .EnumerateFiles("*.vmi")
-            .GroupBy(info => new VmiInfo(File.ReadAllBytes(info.FullName)).VmuFileNameString)
+            .Where(info => info.Length == VmiInfo.Size)
+            .GroupBy(info => new VmiInfo(File.ReadAllBytes(info.FullName)).VmuFileNameString);
+
+        var dcisByName = vmsFolder
+                .EnumerateFiles("*.dci")
+                .Where(info => info.Length >= DirectoryEntry.Size)
+                .GroupBy(info => readDciDirectoryEntry(info).NameString);
+
+        var hostFilesByVmuFileName = vmisByName
+            .Concat(dcisByName)
             .ToDictionary(
                 group => group.Key,
                 group => group.First());
 
+        DirectoryEntry readDciDirectoryEntry(FileInfo dciFileInfo)
+        {
+            using var file = dciFileInfo.OpenRead();
+            var entry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
+            file.ReadExactly(entry.RawData.Span);
+            return entry;
+        }
+
         // Step 3: make host file system changes
         foreach (var vmuFileToDelete in toDelete)
         {
-            if (!vmiFilesByVmuFileName.TryGetValue(vmuFileToDelete, out var vmiInfo))
+            if (!hostFilesByVmuFileName.TryGetValue(vmuFileToDelete, out var hostFileInfo))
                 // Didn't find the corresponding .vmi file in the host system. Nothing to delete.
                 continue;
 
-            vmiInfo.Delete();
-            File.Delete(Path.ChangeExtension(vmiInfo.FullName, ".vms"));
+            hostFileInfo.Delete();
+            if (hostFileInfo.Name.EndsWith(".vmi"))
+                File.Delete(Path.ChangeExtension(hostFileInfo.FullName, ".vms"));
         }
 
         foreach (var entryToWrite in toWrite)
         {
             var onVmuFileName = entryToWrite.NameString;
-            var vmiFileInfo = vmiFilesByVmuFileName.TryGetValue(entryToWrite.NameString, out var existingInfo)
-                ? existingInfo
-                : new FileInfo(Path.Combine(vmsFolder.FullName, $"{onVmuFileName}.vmi")); // new file
-
-            var vmiInfo = CreateVmiInfo(entryToWrite);
-            using var vmiFileStream = vmiFileInfo.Create();
-            vmiFileStream.Write(vmiInfo.RawData.Span);
-
-            using var vmsFile = File.Create(Path.ChangeExtension(vmiFileInfo.FullName, ".vms"));
-            var fatBlock = GetFATBlock();
-            for (var blockId = entryToWrite.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+            if (hostFilesByVmuFileName.TryGetValue(entryToWrite.NameString, out var existingInfo))
             {
-                vmsFile.Write(GetBlock(blockId));
+                if (existingInfo.Name.EndsWith(".vmi"))
+                    writeVmiVms(existingInfo);
+                else if (existingInfo.Name.EndsWith(".dci"))
+                    writeDci(existingInfo);
+                else
+                    throw new InvalidOperationException();
+
+                continue;
+            }
+
+            // new file
+            if (preferredFileFormat == FileFormat.VmiVms)
+                writeVmiVms(new FileInfo(Path.Combine(vmsFolder.FullName, $"{onVmuFileName}.vmi")));
+            else if (preferredFileFormat == FileFormat.Dci)
+                writeDci(new FileInfo(Path.Combine(vmsFolder.FullName, $"{onVmuFileName}.dci")));
+            else
+                throw new InvalidOperationException();
+
+            void writeVmiVms(FileInfo vmiFileInfo)
+            {
+                var vmiInfo = CreateVmiInfo(entryToWrite);
+                using var vmiFileStream = vmiFileInfo.Create();
+                vmiFileStream.Write(vmiInfo.RawData.Span);
+
+                using var vmsFile = File.Create(Path.ChangeExtension(vmiFileInfo.FullName, ".vms"));
+                var fatBlock = GetFATBlock();
+                for (var blockId = entryToWrite.StartFAT; blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+                {
+                    vmsFile.Write(GetBlock(blockId));
+                }
+            }
+
+            void writeDci(FileInfo dciFileInfo)
+            {
+                // dci format consists of the directory entry content, followed by the vms data.
+                using var dciFile = dciFileInfo.Create();
+
+                var outEntry = new DirectoryEntry(new byte[DirectoryEntry.Size]);
+                entryToWrite.RawData.CopyTo(outEntry.RawData);
+                outEntry.StartFAT = 0; // forced to 0 on-disk since its value depends on the destination file system.
+                dciFile.Write(outEntry.RawData.Span);
+
+                var fatBlock = GetFATBlock();
+                for (var blockId = outEntry.StartFAT;blockId != FAT_LastInFile; blockId = fatBlock[blockId])
+                {
+                    var block = this.GetBlock(blockId);
+                    dciFile.Write(block);
+                }
+
+                return;
             }
         }
 
@@ -895,6 +1014,7 @@ internal readonly struct DirectoryEntry
     }
 
     private readonly Memory<byte> _data;
+    internal Memory<byte> RawData => _data;
 
     internal bool HasValue => _data.Length == Size;
 

--- a/src/DreamPotato.Core/Vmu.cs
+++ b/src/DreamPotato.Core/Vmu.cs
@@ -120,6 +120,31 @@ public class Vmu
         _cpu.LazyDebugInfo?.ClearFlash();
     }
 
+    public (bool ok, string? error) LoadDci(string filePath, DateTimeOffset date, bool autoInitializeRTCDate)
+    {
+        if (!filePath.EndsWith(".dci", StringComparison.OrdinalIgnoreCase))
+            return (false, $"DCI file '{filePath}' must have .dci extension.");
+
+        var fileInfo = new FileInfo(filePath);
+        if (!fileInfo.Exists)
+            return (false, $"'{filePath}' does not exist.");
+
+        if (fileInfo.Length > Cpu.InstructionBankSize + DirectoryEntry.Size)
+            return (false, $"'{filePath}': Invalid format");
+
+        Reset(autoInitializeRTCDate ? date : null);
+
+        FileSystem.FlushAndSetHostFileInfo(filePath, vmuFileWriteStream: null);
+        FileSystem.InitializeFileSystem(date);
+        FileSystem.TryWriteDciFile(fileInfo);
+
+        _cpu.LazyDebugInfo?.ClearFlash();
+        _cpu.LazyDebugInfo?.GetBankInfo(InstructionBank.FlashBank0).WaterbearInfo = GetWaterbearInfo(filePath);
+
+        _cpu.ResyncMapleOutbound();
+        return (true, null);
+    }
+
     public (bool ok, string? error) LoadVms(string filePath, DateTimeOffset date, bool autoInitializeRTCDate)
     {
         if (!filePath.EndsWith(".vms", StringComparison.OrdinalIgnoreCase))
@@ -228,7 +253,7 @@ public class Vmu
             _cpu.ResyncMapleOutbound();
     }
 
-    public (bool ok, string? error) SaveVmuAsFolder(string folderPath, FileFormat fileFormat)
+    public (bool ok, string? error) SaveVmuAsFolder(string folderPath, FileFormat preferredFileFormat)
     {
         if (IsDockedToDreamcast)
             _cpu.ResyncMapleInbound();
@@ -237,7 +262,7 @@ public class Vmu
         if (!info.Exists)
             return (false, $"The folder '{info.Name}' does not exist.");
 
-        if (FileSystem.TryReadAllFiles(destDirectory: info, fileFormat) is (false, var error))
+        if (FileSystem.TryReadAllFiles(destDirectory: info, preferredFileFormat) is (false, var error))
             return (false, error);
 
         _cpu.FileSystem.FlushAndSetHostFileInfo(folderPath, vmuFileWriteStream: null);

--- a/src/DreamPotato.Core/Vmu.cs
+++ b/src/DreamPotato.Core/Vmu.cs
@@ -42,6 +42,11 @@ public class Vmu
         FileSystem.InitializeFileSystem(date);
     }
 
+    public void SetPreferredFileFormat(FileFormat preferredFileFormat)
+    {
+        FileSystem.PreferredFileFormat = preferredFileFormat;
+    }
+
     public void InitializeRTCDate(DateTimeOffset date)
     {
         if (_cpu.Pc != 0 || _cpu.CurrentInstructionBankId != InstructionBank.ROM)
@@ -253,7 +258,7 @@ public class Vmu
             _cpu.ResyncMapleOutbound();
     }
 
-    public (bool ok, string? error) SaveVmuAsFolder(string folderPath, FileFormat preferredFileFormat)
+    public (bool ok, string? error) SaveVmuAsFolder(string folderPath)
     {
         if (IsDockedToDreamcast)
             _cpu.ResyncMapleInbound();
@@ -262,7 +267,7 @@ public class Vmu
         if (!info.Exists)
             return (false, $"The folder '{info.Name}' does not exist.");
 
-        if (FileSystem.TryReadAllFiles(destDirectory: info, preferredFileFormat) is (false, var error))
+        if (FileSystem.TryReadAllFiles(destDirectory: info) is (false, var error))
             return (false, error);
 
         _cpu.FileSystem.FlushAndSetHostFileInfo(folderPath, vmuFileWriteStream: null);

--- a/src/DreamPotato.Core/Vmu.cs
+++ b/src/DreamPotato.Core/Vmu.cs
@@ -162,7 +162,7 @@ public class Vmu
             var fileName = Path.GetFileNameWithoutExtension(filePath);
             fileName = fileName[..Math.Min(DirectoryEntry.FileNameLength, fileName.Length)];
             var onVmuFileName = FileSystem.Encoding.GetBytes(fileName);
-            if (FileSystem.TryWriteGameFile(vmsFile, onDiskFileName: fileInfo.Name, onVmuFileName, date, FileCopyProtection.NotCopyProtected) is (false, var error))
+            if (FileSystem.TryWriteVmsOnlyGame(vmsFile, onDiskFileName: fileInfo.Name, onVmuFileName, date, FileCopyProtection.NotCopyProtected) is (false, var error))
                 return (false, error);
         }
 

--- a/src/DreamPotato.Core/Vmu.cs
+++ b/src/DreamPotato.Core/Vmu.cs
@@ -126,6 +126,9 @@ public class Vmu
             return (false, $"VMS file '{filePath}' must have .vms extension.");
 
         var fileInfo = new FileInfo(filePath);
+        if (!fileInfo.Exists)
+            return (false, $"'{filePath}' does not exist.");
+
         if (fileInfo.Length > Cpu.InstructionBankSize)
             return (false, $"VMS file '{filePath}' must be 64KB or smaller to be loaded.");
 
@@ -144,7 +147,7 @@ public class Vmu
             {
                 // Note: this will search from the end of the volume toward the start for a free block
                 var currentBlock = FileSystem.UserRegionLastBlockId;
-                if (FileSystem.TryWriteDataFile(ref currentBlock, vmsFile, vmiInfo) is (false, var error))
+                if (FileSystem.TryWriteDataFileWithVmi(ref currentBlock, vmsFile, vmiInfo) is (false, var error))
                     return (false, error);
             }
             else
@@ -176,6 +179,9 @@ public class Vmu
             return (false, $"VMU file '{filePath}' must have .vmu or .bin extension.");
 
         var fileInfo = new FileInfo(filePath);
+        if (!fileInfo.Exists)
+            return (false, $"'{filePath}' does not exist.");
+
         if (fileInfo.Length != Cpu.InstructionBankSize * 2)
             return (false, $"VMU file '{filePath}' needs to be exactly 128KB in size.");
 
@@ -192,7 +198,7 @@ public class Vmu
     }
 
     /// <summary>Note: this call is transactional for flash and cpu state.</summary>
-    public (bool ok, string? error) LoadVmsFolder(string folderPath, DateTimeOffset date, bool autoInitializeRtcDate)
+    public (bool ok, string? error) LoadFolder(string folderPath, DateTimeOffset date, bool autoInitializeRtcDate)
     {
         var folderInfo = new DirectoryInfo(folderPath);
         if (!folderInfo.Exists)
@@ -222,7 +228,7 @@ public class Vmu
             _cpu.ResyncMapleOutbound();
     }
 
-    public (bool ok, string? error) SaveVmuAsFolder(string folderPath)
+    public (bool ok, string? error) SaveVmuAsFolder(string folderPath, FileFormat fileFormat)
     {
         if (IsDockedToDreamcast)
             _cpu.ResyncMapleInbound();
@@ -231,7 +237,7 @@ public class Vmu
         if (!info.Exists)
             return (false, $"The folder '{info.Name}' does not exist.");
 
-        if (FileSystem.TryReadAllFiles(destDirectory: info) is (false, var error))
+        if (FileSystem.TryReadAllFiles(destDirectory: info, fileFormat) is (false, var error))
             return (false, error);
 
         _cpu.FileSystem.FlushAndSetHostFileInfo(folderPath, vmuFileWriteStream: null);

--- a/src/DreamPotato.MonoGame/Configuration.cs
+++ b/src/DreamPotato.MonoGame/Configuration.cs
@@ -26,6 +26,7 @@ public record Configuration(
     int Volume = Audio.DefaultVolume,
     bool MuteSecondaryVmuAudio = true,
     string? ColorPaletteName = null,
+    FileFormat PreferredFileFormat = FileFormat.VmiVms,
     InputMappings? PrimaryInput = null,
     InputMappings? SecondaryInput = null,
     ViewportSize? ViewportSize = null,

--- a/src/DreamPotato.MonoGame/Game1.cs
+++ b/src/DreamPotato.MonoGame/Game1.cs
@@ -156,6 +156,7 @@ public class Game1 : Game
         {
             var vmu = presenter.Vmu;
             vmu.InitializeFlash(date);
+            vmu.SetPreferredFileFormat(Configuration.PreferredFileFormat);
             if (Configuration.AutoInitializeDate)
                 vmu.InitializeRTCDate(date);
 
@@ -348,7 +349,7 @@ public class Game1 : Game
     internal (bool ok, string? error) SaveVmuAsFolder(Vmu vmu, string folderPath)
     {
         Debug.Assert(!IsIntegratedMode && RecentFilesInfo is { });
-        if (vmu.SaveVmuAsFolder(folderPath, Configuration.PreferredFileFormat) is (false, var error))
+        if (vmu.SaveVmuAsFolder(folderPath) is (false, var error))
             return (false, error);
 
         UpdateWindowTitle();
@@ -399,6 +400,8 @@ public class Game1 : Game
     internal void Configuration_PreferredFileFormatChanged(FileFormat format)
     {
         Configuration = Configuration with { PreferredFileFormat = format };
+        PrimaryVmu.SetPreferredFileFormat(Configuration.PreferredFileFormat);
+        _secondaryVmuPresenter.Vmu.SetPreferredFileFormat(Configuration.PreferredFileFormat);
     }
 
     internal void Configuration_DreamcastPortChanged(DreamcastPort dreamcastPort)

--- a/src/DreamPotato.MonoGame/Game1.cs
+++ b/src/DreamPotato.MonoGame/Game1.cs
@@ -261,6 +261,15 @@ public class Game1 : Game
                 return;
             }
         }
+        else if (extension.Equals(".dci", StringComparison.OrdinalIgnoreCase))
+        {
+            if (vmu.LoadDci(filePath, date, autoInitializeRTCDate: Configuration.AutoInitializeDate) is (false, var error))
+            {
+                _userInterface.ShowToast(presenter, error ?? "Unknown error");
+                dropRecentIfNotExists();
+                return;
+            }
+        }
         else if (extension.Equals(".vmu", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".bin", StringComparison.OrdinalIgnoreCase))
         {

--- a/src/DreamPotato.MonoGame/Game1.cs
+++ b/src/DreamPotato.MonoGame/Game1.cs
@@ -387,6 +387,11 @@ public class Game1 : Game
         ColorPalette = palette;
     }
 
+    internal void Configuration_PreferredFileFormatChanged(FileFormat format)
+    {
+        Configuration = Configuration with { PreferredFileFormat = format };
+    }
+
     internal void Configuration_DreamcastPortChanged(DreamcastPort dreamcastPort)
     {
         Debug.Assert(!IsIntegratedMode);

--- a/src/DreamPotato.MonoGame/Game1.cs
+++ b/src/DreamPotato.MonoGame/Game1.cs
@@ -244,7 +244,7 @@ public class Game1 : Game
             if (!checkDistinctPath())
                 return;
 
-            var (ok, error) = vmu.LoadVmsFolder(filePath, date, autoInitializeRtcDate: Configuration.AutoInitializeDate);
+            var (ok, error) = vmu.LoadFolder(filePath, date, autoInitializeRtcDate: Configuration.AutoInitializeDate);
             if (!ok)
             {
                 _userInterface.ShowToast(presenter, error ?? "Unknown error");
@@ -339,7 +339,7 @@ public class Game1 : Game
     internal (bool ok, string? error) SaveVmuAsFolder(Vmu vmu, string folderPath)
     {
         Debug.Assert(!IsIntegratedMode && RecentFilesInfo is { });
-        if (vmu.SaveVmuAsFolder(folderPath) is (false, var error))
+        if (vmu.SaveVmuAsFolder(folderPath, Configuration.PreferredFileFormat) is (false, var error))
             return (false, error);
 
         UpdateWindowTitle();

--- a/src/DreamPotato.MonoGame/UI/UserInterface.cs
+++ b/src/DreamPotato.MonoGame/UI/UserInterface.cs
@@ -1065,21 +1065,26 @@ partial class UserInterface
                 ImGui.Text("Preferred File Format");
                 ImGui.SameLine();
 
-                var fileFormats = Enum.GetNames<FileFormat>();
-                var fileFormat = configuration.PreferredFileFormat;
-                var selectedIndex = (int)fileFormat;
-                ImGui.PushID("PreferredFileFormatCombo");
-                ImGui.Combo("", ref selectedIndex, fileFormats, fileFormats.Length);
-                ImGui.PopID();
-                if ((int)fileFormat != selectedIndex)
-                    _game.Configuration_PreferredFileFormatChanged((FileFormat)selectedIndex);
-
                 ImGui.SameLine();
                 ImGui.Text("(?)");
                 if (ImGui.IsItemHovered())
                 {
-                    // TODO2: tooltip for what this setting means
+                    ImGui.BeginTooltip();
+                    ImGui.Text("""
+                        Sets the file format used for
+                        "Save As Folder" and similar commands.
+                        """);
+                    ImGui.EndTooltip();
                 }
+
+                var fileFormat = configuration.PreferredFileFormat;
+                var selectedIndex = (int)fileFormat;
+                ImGui.SetNextItemWidth(CalcComboWidth(longestItem: FileFormatExtensions.Names[0]));
+                ImGui.PushID("PreferredFileFormatCombo");
+                ImGui.Combo("", ref selectedIndex, FileFormatExtensions.Names, FileFormatExtensions.Names.Length);
+                ImGui.PopID();
+                if ((int)fileFormat != selectedIndex)
+                    _game.Configuration_PreferredFileFormatChanged((FileFormat)selectedIndex);
             }
 
             // Dreamcast Port

--- a/src/DreamPotato.MonoGame/UI/UserInterface.cs
+++ b/src/DreamPotato.MonoGame/UI/UserInterface.cs
@@ -1076,6 +1076,7 @@ partial class UserInterface
                         """);
                     ImGui.EndTooltip();
                 }
+                ImGui.SameLine();
 
                 var fileFormat = configuration.PreferredFileFormat;
                 var selectedIndex = (int)fileFormat;

--- a/src/DreamPotato.MonoGame/UI/UserInterface.cs
+++ b/src/DreamPotato.MonoGame/UI/UserInterface.cs
@@ -1060,6 +1060,28 @@ partial class UserInterface
                 }
             }
 
+            // File Format
+            {
+                ImGui.Text("Preferred File Format");
+                ImGui.SameLine();
+
+                var fileFormats = Enum.GetNames<FileFormat>();
+                var fileFormat = configuration.PreferredFileFormat;
+                var selectedIndex = (int)fileFormat;
+                ImGui.PushID("PreferredFileFormatCombo");
+                ImGui.Combo("", ref selectedIndex, fileFormats, fileFormats.Length);
+                ImGui.PopID();
+                if ((int)fileFormat != selectedIndex)
+                    _game.Configuration_PreferredFileFormatChanged((FileFormat)selectedIndex);
+
+                ImGui.SameLine();
+                ImGui.Text("(?)");
+                if (ImGui.IsItemHovered())
+                {
+                    // TODO2: tooltip for what this setting means
+                }
+            }
+
             // Dreamcast Port
             if (!_game.IsIntegratedMode)
             {

--- a/src/DreamPotato.MonoGame/UI/UserInterface.cs
+++ b/src/DreamPotato.MonoGame/UI/UserInterface.cs
@@ -300,7 +300,7 @@ partial class UserInterface
             return;
         }
 
-        var result = Dialog.FileOpen("vmu,bin,vms", defaultPath: null);
+        var result = Dialog.FileOpen("vmu,bin,vms,dci", defaultPath: null);
         if (result.IsOk)
         {
             _game.LoadAndStartVmsOrVmuFile(presenter, result.Path);

--- a/src/DreamPotato.MonoGame/VmuPresenter.cs
+++ b/src/DreamPotato.MonoGame/VmuPresenter.cs
@@ -335,9 +335,6 @@ class VmuPresenter
         _dynamicSound.SubmitBuffer(args.Buffer, args.Start, args.Length);
     }
 
-    internal void UpdateVolume(int volume)
-        => Vmu.Audio.Volume = volume;
-
     internal void DockOrEject()
     {
         Vmu.DockOrEjectToDreamcast();

--- a/src/DreamPotato.Tests/FileSystemTests.cs
+++ b/src/DreamPotato.Tests/FileSystemTests.cs
@@ -23,7 +23,7 @@ public class FileSystemTests : IDisposable
         verifyRootBlock();
         verifyFATBlock();
         using var gameFile = File.OpenRead("TestSource/helloworld.vms");
-        var (success, _) = fileSystem.TryWriteGameFile(gameFile, "HelloWorld", FileSystem.Encoding.GetBytes("HelloWorld"), date, FileCopyProtection.NotCopyProtected);
+        var (success, _) = fileSystem.TryWriteVmsOnlyGame(gameFile, "HelloWorld", FileSystem.Encoding.GetBytes("HelloWorld"), date, FileCopyProtection.NotCopyProtected);
         Assert.True(success);
 
         void verifyRootBlock()
@@ -95,7 +95,7 @@ public class FileSystemTests : IDisposable
         var fileSystem = new FileSystem(flash);
         fileSystem.InitializeFileSystem(date);
         using var gameFile = File.OpenRead("TestSource/helloworld.vms");
-        var (success, _) = fileSystem.TryWriteGameFile(gameFile, "HelloWorld", FileSystem.Encoding.GetBytes("HelloWorld"), date, FileCopyProtection.NotCopyProtected);
+        var (success, _) = fileSystem.TryWriteVmsOnlyGame(gameFile, "HelloWorld", FileSystem.Encoding.GetBytes("HelloWorld"), date, FileCopyProtection.NotCopyProtected);
         Assert.True(success);
 
         var fatEntry = fileSystem.GetBlock(FileSystem.FATBlockId);

--- a/src/DreamPotato.Tests/FileSystemTests.cs
+++ b/src/DreamPotato.Tests/FileSystemTests.cs
@@ -126,7 +126,7 @@ public class FileSystemTests : IDisposable
         var fileSystem = new FileSystem(flash);
 
         var outDir = _tempRoot.CreateSubdirectory("ReadFiles_01");
-        var (ok, error) = fileSystem.TryReadAllFiles(outDir, FileFormat.VmiVms);
+        var (ok, error) = fileSystem.TryReadAllFiles(outDir);
         Assert.True(ok, error);
 
         var fileNames = string.Join(Environment.NewLine,
@@ -177,7 +177,7 @@ public class FileSystemTests : IDisposable
         var fileSystem1 = new FileSystem(flash1);
 
         var vmsFolder = _tempRoot.CreateSubdirectory("ReadFiles_01");
-        var (ok, error) = fileSystem1.TryReadAllFiles(vmsFolder, FileFormat.VmiVms);
+        var (ok, error) = fileSystem1.TryReadAllFiles(vmsFolder);
         Assert.True(ok, error);
 
         var flash2 = new byte[Cpu.FlashSize];
@@ -262,7 +262,7 @@ public class FileSystemTests : IDisposable
 
         // Round trip from flash back to VMS folder
         var vmsFolder2 = _tempRoot.CreateSubdirectory("ReadFiles_02");
-        (ok, error) = fileSystem2.TryReadAllFiles(vmsFolder2, FileFormat.VmiVms);
+        (ok, error) = fileSystem2.TryReadAllFiles(vmsFolder2);
         Assert.True(ok, error);
 
         // All files in 'vmsFolder' are present in 'vmsFolder2'

--- a/src/DreamPotato.Tests/FileSystemTests.cs
+++ b/src/DreamPotato.Tests/FileSystemTests.cs
@@ -126,7 +126,7 @@ public class FileSystemTests : IDisposable
         var fileSystem = new FileSystem(flash);
 
         var outDir = _tempRoot.CreateSubdirectory("ReadFiles_01");
-        var (ok, error) = fileSystem.TryReadAllFiles(outDir);
+        var (ok, error) = fileSystem.TryReadAllFiles(outDir, FileFormat.VmiVms);
         Assert.True(ok, error);
 
         var fileNames = string.Join(Environment.NewLine,
@@ -177,7 +177,7 @@ public class FileSystemTests : IDisposable
         var fileSystem1 = new FileSystem(flash1);
 
         var vmsFolder = _tempRoot.CreateSubdirectory("ReadFiles_01");
-        var (ok, error) = fileSystem1.TryReadAllFiles(vmsFolder);
+        var (ok, error) = fileSystem1.TryReadAllFiles(vmsFolder, FileFormat.VmiVms);
         Assert.True(ok, error);
 
         var flash2 = new byte[Cpu.FlashSize];
@@ -262,7 +262,7 @@ public class FileSystemTests : IDisposable
 
         // Round trip from flash back to VMS folder
         var vmsFolder2 = _tempRoot.CreateSubdirectory("ReadFiles_02");
-        (ok, error) = fileSystem2.TryReadAllFiles(vmsFolder2);
+        (ok, error) = fileSystem2.TryReadAllFiles(vmsFolder2, FileFormat.VmiVms);
         Assert.True(ok, error);
 
         // All files in 'vmsFolder' are present in 'vmsFolder2'


### PR DESCRIPTION
- Allow opening standalone .dci files (either game or data files). This behaves similarly to opening a vms file (with optional companion vmi file)
- Allow opening folders of .dci files. I found these really are nicer to work with, having just one file per savegame instead of two that you have to keep together, is just easier.
- Allow saving as a folder of .dci files. Whether to use vmi/vms or dci with Save As Folder command is controlled by a new "Preferred File Format" setting.

Quality of this code could be better, there is some copy/pasting that could be eliminated in the file system handling in general, but I feel reasonably confident the code is correct.